### PR TITLE
PAPP-24016 Upgrade django to the latest version to fix ProdSec scan

### DIFF
--- a/office365.json
+++ b/office365.json
@@ -4779,7 +4779,7 @@
         "wheel": [
             {
                 "module": "Django",
-                "input_file": "wheels/py3/Django-3.2.5-py3-none-any.whl"
+                "input_file": "wheels/py3/Django-4.0.2-py3-none-any.whl"
             },
             {
                 "module": "asgiref",
@@ -4804,10 +4804,6 @@
             {
                 "module": "python_magic",
                 "input_file": "wheels/shared/python_magic-0.4.18-py2.py3-none-any.whl"
-            },
-            {
-                "module": "pytz",
-                "input_file": "wheels/shared/pytz-2021.3-py2.py3-none-any.whl"
             },
             {
                 "module": "requests",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 beautifulsoup4==4.9.1
-Django==3.2.5
+Django==4.0.2
 python-magic==0.4.18
 requests==2.25.0


### PR DESCRIPTION
### Changes
* Updated Django to fix ProdSec scan.

### Test
* WhiteSource is now showing no vulnerability.
* Non-FIPS Py3.9 Green pipeline: pipelines/4512918